### PR TITLE
ASD-13105 - Added status retry timeout to prevent infinite loop

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/backend/src/main/java/com/gooddata/connector/AbstractConnector.java
+++ b/backend/src/main/java/com/gooddata/connector/AbstractConnector.java
@@ -506,8 +506,14 @@ public abstract class AbstractConnector implements Connector {
         l.debug("Checking data transfer status.");
         String status = "";
         int retryCount = 0;
+        long startTime = System.currentTimeMillis();
         while (!"OK".equalsIgnoreCase(status) && !"ERROR".equalsIgnoreCase(status) && !"WARNING".equalsIgnoreCase(status)) {
             try {
+                long elapsedTime = (System.currentTimeMillis() - startTime);
+                if (elapsedTime > Constants.LOADING_STATUS_RETRY_TIMEOUT) {
+                    throw new GdcIntegrationErrorException("Loading status check exceeded the timeout threshold (" + Constants.LOADING_STATUS_RETRY_TIMEOUT + ")");
+                }
+
                 status = ctx.getRestApi(p).getLoadingStatus(taskUri);
                 l.debug("Loading status = " + status);
                 Thread.sleep(Constants.POLL_INTERVAL);

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/src/main/java/com/gooddata/Constants.java
+++ b/common/src/main/java/com/gooddata/Constants.java
@@ -56,5 +56,6 @@ public class Constants {
     // polling interval
     public final static int POLL_INTERVAL = 10000;
     public final static int RETRY_INTERVAL = 1000;
+    public final static long LOADING_STATUS_RETRY_TIMEOUT = 3600000;
 
 }

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/notification/pom.xml
+++ b/notification/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.gooddata.cl</groupId>
     <artifactId>gooddata-cl</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <name>gooddata-cl</name>
     <description>GoodData CL command line tool and Java API framework.</description>
     <url>http://developer.gooddata.com</url>

--- a/sfdc/pom.xml
+++ b/sfdc/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
@joshcbarnes please review, FYI @msquance 

GoodData API wrapper keeps polling the upload status endpoint until the upload has terminated.  It's possible for upload to get stuck if the wrapper keeps getting "PENDING" response.  I've added timeout logic for the status check to throw an exception after 1 hour.
